### PR TITLE
fix: rename Paygop Paybill to Fineract Paybill in environment files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
         * [CP-3621] - Matomo integration
         * [CP-3641] - Updgrade to Angular 16
+        * [CP-3750] - Rename Paygop Paybill to Fineract Paybill
 
 ## Version 1.1.7
 

--- a/src/environments/environment.kubernetes.ts
+++ b/src/environments/environment.kubernetes.ts
@@ -59,7 +59,7 @@ export let environment = {
       value: '8167094',
     },
     {
-      option: 'PAYGOPS_PAYBILL',
+      option: 'FINERACT_PAYBILL',
       type: 'PAYBILL',
       value: '840706',
     },

--- a/src/environments/environment.kubernetes.ts
+++ b/src/environments/environment.kubernetes.ts
@@ -59,7 +59,7 @@ export let environment = {
       value: '8167094',
     },
     {
-      option: 'FINERACT_PAYBILL',
+      option: 'FINERACT_KE_PAYBILL',
       type: 'PAYBILL',
       value: '840706',
     },

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -53,7 +53,7 @@ export let environment = {
       value: '8167094',
     },
     {
-      option: 'PAYGOPS_PAYBILL',
+      option: 'FINERACT_PAYBILL',
       type: 'PAYBILL',
       value: '840706',
     },

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -53,7 +53,7 @@ export let environment = {
       value: '8167094',
     },
     {
-      option: 'FINERACT_PAYBILL',
+      option: 'FINERACT_KE_PAYBILL',
       type: 'PAYBILL',
       value: '840706',
     },

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -70,7 +70,7 @@ export let environment = {
       value: '8167094',
     },
     {
-      option: 'PAYGOPS_PAYBILL',
+      option: 'FINERACT_PAYBILL',
       type: 'PAYBILL',
       value: '840706',
     },

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -70,7 +70,7 @@ export let environment = {
       value: '8167094',
     },
     {
-      option: 'FINERACT_PAYBILL',
+      option: 'FINERACT_KE_PAYBILL',
       type: 'PAYBILL',
       value: '840706',
     },


### PR DESCRIPTION
## Description
Change Paygops Paybill as a label to Fineract Paybill in the Search Incoming Request interface.
* https://oneacrefund.atlassian.net/browse/CP-3750
<img width="1146" height="623" alt="image" src="https://github.com/user-attachments/assets/5ce00562-e3c6-4b11-b228-e3f868414449" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Renamed the Paybill option to “Fineract Paybill” across environments and user-facing lists. Users will now see the updated name wherever Paybill options are displayed (e.g., payment short codes and selection menus).
- Documentation
  - Updated release notes (v1.1.8) to include the Paybill rename entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->