### PR TITLE
fix(CP-4012) Add missing translation keys

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -256,5 +256,15 @@
     "DESELECT_ALL": "Deselect All",
     "DELETE_ROLE": "Delete Role",
     "CONFIRM_DELETE": "Are you sure you want to delete this role? This action is irreversible."
+  },
+  "DIALOGS": {
+    "DELETE": "Confirm Delete",
+    "DELETE_CONFIRMATION": "Are you sure you want to delete ",
+    "CLOSE": "Close",
+    "CONFIRM": "Confirm",
+    "ARE_YOU_SURE": "Are you sure?",
+    "YES": "Yes",
+    "NO": "No",
+    "CANCEL": "Cancel"
   }
 }

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -256,5 +256,15 @@
         "DESELECT_ALL": "Désélectionner Tout",
         "DELETE_ROLE": "Supprimer le Rôle",
         "CONFIRM_DELETE": "Êtes-vous sûr de vouloir supprimer ce rôle ? Cette action est irréversible."
-    }
+    },
+    "DIALOGS": {
+        "DELETE": "Supprimer",
+        "DELETE_CONFIRMATION": "Êtes-vous sûr de vouloir supprimer ",
+        "CLOSE": "Fermer",
+        "CONFIRM": "Confirmer",
+        "ARE_YOU_SURE": "Êtes-vous sûr ?",
+        "YES": "Oui",
+        "NO": "Non",
+        "CANCEL": "Annuler"
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added English and French translation strings for delete confirmation dialogs, enabling localized UI text for confirmation messages, action buttons, and user prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->